### PR TITLE
Fix Adobe APP14 skip logic

### DIFF
--- a/jpeg_parser.c
+++ b/jpeg_parser.c
@@ -57,7 +57,8 @@ void parse_app14_adobe(FILE *file, long offset, uint16_t length)
 		return;
 	}
 
-	fseek(file, 7, SEEK_CUR);
+        /* Skip version and flags (6 bytes) */
+        fseek(file, 6, SEEK_CUR);
 	uint8_t color_transform;
 	fread(&color_transform, 1, 1, file);
 	adobe_color_transform = color_transform;
@@ -72,7 +73,8 @@ void parse_app14_adobe(FILE *file, long offset, uint16_t length)
 	else
 		printf("Unknown\n");
 
-	fseek(file, length - 5 - 2 - 8, SEEK_CUR);
+        /* Skip remaining bytes after reading ColorTransform */
+        fseek(file, length - 5 - 2 - 7, SEEK_CUR);
 }
 
 void parse_jpeg_segments(FILE *file)

--- a/tests/run_samples.sh
+++ b/tests/run_samples.sh
@@ -25,4 +25,4 @@ check_color_space() {
 }
 
 check_color_space images/rgb.jpeg "Possibly RGB"
-check_color_space images/cmyk.jpeg "Unknown 4-component"
+check_color_space images/cmyk.jpeg "CMYK"


### PR DESCRIPTION
## Summary
- correct byte skipping in `parse_app14_adobe`
- update sample tests to look for CMYK output

## Testing
- `tests/run_samples.sh`

------
https://chatgpt.com/codex/tasks/task_e_68400da024508331b4d6c2461cdb42ca